### PR TITLE
Annotations: Fix Source Package Bugs

### DIFF
--- a/src/SharpSchema.Annotations.Source/SharpSchema.Annotations.Source.csproj
+++ b/src/SharpSchema.Annotations.Source/SharpSchema.Annotations.Source.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>SOURCE</DefineConstants>
+    <DefineConstants>SHARPSCHEMA_SOURCE</DefineConstants>
     <IsPackable>true</IsPackable>
     <PackageId>SharpSchema.Annotations.Source</PackageId>
     <Product>SharpSchema</Product>

--- a/src/SharpSchema.Annotations/SchemaAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaAttribute.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Represents a base class for schema attributes.
 /// </summary>
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public abstract class SchemaAttribute : Attribute
 #else
 internal abstract class SchemaAttribute : Attribute

--- a/src/SharpSchema.Annotations/SchemaConstAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaConstAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Specifies a constant value for a property or field in a schema.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaConstAttribute(object value) : SchemaAttribute
 #else
 internal class SchemaConstAttribute(object value) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaEnumValueAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaEnumValueAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Specifies the value of an enum member in a schema.
 /// </summary>
 [AttributeUsage(AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaEnumValueAttribute(string value) : SchemaAttribute
 #else
 internal class SchemaEnumValueAttribute(string value) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaFormatAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaFormatAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace SharpSchema.Annotations;
 /// This attribute is used to specify the format of a schema.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaFormatAttribute(string format) : SchemaAttribute
 #else
 internal class SchemaFormatAttribute(string format) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaIgnoreAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaIgnoreAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Specifies that the annotated element should be ignored during schema generation.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Struct)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaIgnoreAttribute : SchemaAttribute
 #else
 internal class SchemaIgnoreAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaLengthRangeAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaLengthRangeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -9,7 +11,8 @@ namespace SharpSchema.Annotations;
 /// <remarks>
 /// This attribute can be used to define the minimum and maximum length of a schema.
 /// </remarks>
-#if ASSEMBLY
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaLengthRangeAttribute : SchemaAttribute
 #else
 internal class SchemaLengthRangeAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaMetaAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaMetaAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Represents a schema meta attribute.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Enum)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaMetaAttribute : SchemaAttribute
 #else
 internal class SchemaMetaAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaOverrideAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaOverrideAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace SharpSchema.Annotations;
 /// This attribute is used to specify a custom value for a schema.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaOverrideAttribute(string value) : SchemaAttribute
 #else
 internal class SchemaOverrideAttribute(string value) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaPropertiesRangeAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaPropertiesRangeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace SharpSchema.Annotations;
 /// This attribute can be used to specify the minimum and maximum number of properties allowed in a schema.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaPropertiesRangeAttribute : SchemaAttribute
 #else
 internal class SchemaPropertiesRangeAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaRegexAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaRegexAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace SharpSchema.Annotations;
 /// This attribute is used to specify a regular expression pattern that a property value must match in order to be considered valid.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaRegexAttribute(string pattern) : SchemaAttribute
 #else
 internal class SchemaRegexAttribute(string pattern) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaRequiredAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaRequiredAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Indicates whether a property is required in a schema.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaRequiredAttribute(bool isRequired = true) : SchemaAttribute
 #else
 internal class SchemaRequiredAttribute(bool isRequired = true) : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaRootAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaRootAttribute.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
 /// Marks a class or struct as a schema root.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaRootAttribute : SchemaAttribute
 #else
 internal class SchemaRootAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SchemaValueRangeAttribute.cs
+++ b/src/SharpSchema.Annotations/SchemaValueRangeAttribute.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Charles Willis. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace SharpSchema.Annotations;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace SharpSchema.Annotations;
 /// This attribute can be used to define the minimum and maximum values allowed for a property in a schema.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
-#if ASSEMBLY
+#if SHARPSCHEMA_ASSEMBLY
 public class SchemaValueRangeAttribute : SchemaAttribute
 #else
 internal class SchemaValueRangeAttribute : SchemaAttribute

--- a/src/SharpSchema.Annotations/SharpSchema.Annotations.csproj
+++ b/src/SharpSchema.Annotations/SharpSchema.Annotations.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>SharpSchema.Annotations</PackageId>
     <Product>SharpSchema</Product>
     <Description>Annotations library for the SharpSchema project.</Description>
-    <DefineConstants>ASSEMBLY</DefineConstants>
+    <DefineConstants>SHARPSCHEMA_ASSEMBLY</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Instead of 'ASSEMBLY' use the compile constant 'SCHEMASHARP_ASSEMBLY' because it's less likely to conflict with other constants.

Include necessary using statements in all Annotations.