### PR TITLE
Merge release/v0.3 to main

### DIFF
--- a/SharpSchema.sln
+++ b/SharpSchema.sln
@@ -45,6 +45,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpSchema.Annotations.Source", "src\SharpSchema.Annotations.Source\SharpSchema.Annotations.Source.csproj", "{636AF0A7-ABCF-428B-9E81-F42A998A0A09}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{7DF0F79D-3609-4DCF-8F10-EAB6ED6A782C}"
+	ProjectSection(SolutionItems) = preProject
+		docs\ConversionRules.md = docs\ConversionRules.md
+		docs\SchemaAttributes.md = docs\SchemaAttributes.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/docs/SchemaAttributes.md
+++ b/docs/SchemaAttributes.md
@@ -150,6 +150,3 @@ Specifies a value range for a schema property.
 [SchemaValueRange(Min = 1.0, Max = 100.0)]
 public double ValueRangeProperty { get; set; }
 ```
-
-
-

--- a/src/SharpSchema/JsonSchemaBuilderExtensions.cs
+++ b/src/SharpSchema/JsonSchemaBuilderExtensions.cs
@@ -261,15 +261,16 @@ public static class JsonSchemaBuilderExtensions
             // if the property has a regex attribute, set the pattern
             if (property.TryGetCustomAttributeData<SchemaRegexAttribute>(out CustomAttributeData? regexCad))
             {
-                if (regexCad.TryGetNamedArgument(nameof(SchemaRegexAttribute.ApplyToPropertyName), out bool? applyToPropertyName))
+                bool applyToPropertyName = regexCad.TryGetNamedArgument(nameof(SchemaRegexAttribute.ApplyToPropertyName), out bool? applyToPropertyNameValue)
+                    ? applyToPropertyNameValue.Value
+                    : false;
+
+                if (!applyToPropertyName)
                 {
-                    if (!applyToPropertyName.Value)
+                    string? pattern = regexCad.GetConstructorArgument<string>(0);
+                    if (pattern is not null)
                     {
-                        string? pattern = regexCad.GetConstructorArgument<string>(0);
-                        if (pattern is not null)
-                        {
-                            builder = builder.Pattern(pattern);
-                        }
+                        builder = builder.Pattern(pattern);
                     }
                 }
             }

--- a/test/SharpSchema.Tests/SchemaAttributeTests.cs
+++ b/test/SharpSchema.Tests/SchemaAttributeTests.cs
@@ -108,6 +108,17 @@ public class SchemaAttributeTests(ITestOutputHelper outputHelper) : TestBase(out
         Assert.Equal(10U, propertySchema.GetMaxLength());
     }
 
+    [Fact]
+    public void SchemaRegexPattern_Applies_ToPropertySchema()
+    {
+        TypeConverter converter = new();
+        JsonSchema schema = converter.Convert(RootTypeContext.FromType<RegexObject>());
+        this.OutputSchema(schema);
+        JsonSchema? propertySchema = schema.GetProperties()?.Values.First();
+        Assert.NotNull(propertySchema);
+        Assert.Equal("^[a-zA-Z0-9]*$", propertySchema.GetPatternValue());
+    }
+
     [SchemaPropertiesRange(Min = SchemaMinPropertiesValue, Max = SchemaMaxPropertiesValue)]
     private class MinMaxObject
     {
@@ -145,4 +156,6 @@ public class SchemaAttributeTests(ITestOutputHelper outputHelper) : TestBase(out
         [SchemaLengthRange(Min = 1, Max = 10)]
         public required string TestProperty2 { get; init; }
     }
+
+    private record RegexObject([property: SchemaRegex("^[a-zA-Z0-9]*$")] string TestProperty);
 }


### PR DESCRIPTION
Enhanced `JsonSchemaBuilderExtensions.cs` to better handle `SchemaRegexAttribute`, checking for `ApplyToPropertyName` argument and defaulting to `false` if not specified.

resolves #47 