### PR TITLE
Update JsonSchema.Net version and adjust package paths

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="JsonSchema.Net" Version="7.2.3" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="SharpMeta" Version="0.2.5-rc" />

--- a/src/SharpSchema.Annotations.Source/SharpSchema.Annotations.Source.csproj
+++ b/src/SharpSchema.Annotations.Source/SharpSchema.Annotations.Source.csproj
@@ -12,6 +12,6 @@
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\SharpSchema.Annotations\**\*.cs" Pack="true" PackagePath="content\;contentFiles\cs\netstandard2.0\" />
+    <Compile Include="..\SharpSchema.Annotations\**\*.cs" Pack="true" PackagePath="content\SharpSchema\;contentFiles\cs\netstandard2.0\SharpSchema\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Bump `JsonSchema.Net` package version from `7.2.3` to `7.3.0` in `Directory.Packages.props`.
- Modify `PackagePath` in `SharpSchema.Annotations.Source.csproj` for better organization of compiled files.