### PR TITLE
Add verbosity control to GenerateCommandHandler

### DIFF
--- a/src/SharpSchema.Tool/GenerateCommandHandler.cs
+++ b/src/SharpSchema.Tool/GenerateCommandHandler.cs
@@ -146,7 +146,7 @@ internal class GenerateCommandHandler(
                     OnInfo = console.WriteLine
                 };
             default:
-                console.Error.Write("Invalid verbosity level.\n");
+                console.Error.Write("Invalid verbosity level. Valid levels are: Quiet, Normal, Diagnostic.\n");
                 return SharpResolverLogger.Console;
         }
     }


### PR DESCRIPTION
Updated GenerateCommandHandler to accept a verbosity parameter, allowing for conditional logging based on verbosity levels. Introduced a new Verbosity enum in Program.cs to define levels: Normal, Quiet, and Diagnostic. Added command-line options for setting verbosity and suppressing output, enhancing user control over logging behavior.

This changes the default behavior of the assembly loader output which will no longer display "Assembly added" message for Normal verbosity.